### PR TITLE
Add public npm publish config

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,10 @@
     "url": "git://github.com/biggora/device-uuid.git"
   },
   "license": "MIT",
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://npmjs.org"
+  },
   "author": {
     "name": "Alexey Gordeyev",
     "email": "aleksej@gordejev.lv",


### PR DESCRIPTION
## Summary

Adds `publishConfig` to the root package manifest so npm publishes target the public registry with public access.

## Validation

- Parsed `package.json` with `jq`
- Confirmed `publishConfig` equals `{ "access": "public", "registry": "https://npmjs.org" }`

Paperclip issue: OPE-48