### PR TITLE
Fix E2E clean checkout build prerequisite

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -41,7 +41,7 @@ export default defineConfig({
     },
   ],
   webServer: {
-    command: 'npx http-server . -p 18080 -c-1 --cors',
+    command: 'npm run build --silent && npx http-server . -p 18080 -c-1 --cors',
     url: 'http://localhost:18080',
     reuseExistingServer: false,
     timeout: 120000,


### PR DESCRIPTION
## Summary
- Build the device-uuid bundle before Playwright starts the static http-server.
- Keeps tests/e2e/test-page.html loading /dist/index.browser.min.js, but makes the bundle available after a clean npm ci.

## Root Cause
The E2E test page loads /dist/index.browser.min.js, while dist/ is ignored and absent in a clean checkout. The Playwright web server previously served the repo without generating dist first, so window.DeviceUUID was undefined.

## Verification
- npm ci && npm run test:e2e (120 passed)