### PR TITLE
[codex] Fix device UUID ReDoS alerts

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -87,7 +87,7 @@ export const BROWSER_PATTERNS: Readonly<BrowserPatterns> = {
  * Operating system detection patterns
  */
 export const OS_PATTERNS: Readonly<OSPatterns> = {
-  Windows11: /windows nt 10\.0.*(?:; win64; x64|; wow64).*(?:rv:|edg\/|chrome\/).*?(\d+)/i,
+  Windows11: /windows nt 10\.0/i,
   Windows10: /windows nt 10\.0/i,
   Windows81: /windows nt 6\.3/i,
   Windows8: /windows nt 6\.2/i,
@@ -126,8 +126,8 @@ export const OS_PATTERNS: Readonly<OSPatterns> = {
   Wii: /wii/i,
   PS3: /playstation 3/i,
   PSP: /playstation portable/i,
-  iPad: /\(iPad.*os (\d+)[._](\d+)/i,
-  iPhone: /\(iPhone.*os (\d+)[._](\d+)/i,
+  iPad: /\(ipad\b/i,
+  iPhone: /\(iphone\b/i,
   Bada: /Bada\/(\d+)\.(\d+)/i,
   Curl: /curl\/(\d+)\.(\d+)\.(\d+)/i,
 } as const;

--- a/src/core/DeviceUUID.ts
+++ b/src/core/DeviceUUID.ts
@@ -219,21 +219,56 @@ export class DeviceUUID {
   }
 
   /**
+   * Read a decimal integer at a known offset without applying an unbounded regex
+   * to the whole user-agent string.
+   */
+  private readLeadingInteger(source: string, start: number): number | null {
+    let end = start;
+    while (end < source.length) {
+      const code = source.charCodeAt(end);
+      if (code < 48 || code > 57) break;
+      end++;
+    }
+
+    if (end === start) return null;
+    return Number.parseInt(source.slice(start, end), 10);
+  }
+
+  private getWindows11BrowserMajorVersion(source: string): number | null {
+    const lowerSource = source.toLowerCase();
+    if (!lowerSource.includes('windows nt 10.0')) return null;
+    if (!lowerSource.includes('; win64; x64') && !lowerSource.includes('; wow64')) return null;
+
+    for (const marker of ['rv:', 'edg/', 'chrome/']) {
+      const markerIndex = lowerSource.indexOf(marker);
+      if (markerIndex === -1) continue;
+
+      const version = this.readLeadingInteger(source, markerIndex + marker.length);
+      if (version !== null) return version;
+    }
+
+    return null;
+  }
+
+  private hasIOSDeviceOS(source: string, device: 'ipad' | 'iphone'): boolean {
+    const lowerSource = source.toLowerCase();
+    const start = lowerSource.indexOf(`(${device}`);
+    if (start === -1) return false;
+
+    const end = lowerSource.indexOf(')', start);
+    const deviceSection = lowerSource.slice(start, end === -1 ? lowerSource.length : end);
+    return deviceSection.includes(' os ') || deviceSection.includes(` ${device} os `);
+  }
+
+  /**
    * Get operating system from user agent string
    */
   private getOS(source: string): string {
     // Windows versions - check Windows 11 before Windows 10
-    if (this.osPatterns.Windows11.test(source)) {
-      // Windows 11 uses NT 10.0 but can be detected by platform version
-      const match = source.match(this.osPatterns.Windows11);
-      if (match && match[1]) {
-        const version = parseInt(match[1]);
-        // Chrome/Edge version >= 96 typically indicates Windows 11
-        if (version >= 96) {
-          this.agent.isWindows = true;
-          return 'Windows 11';
-        }
-      }
+    const windows11BrowserMajorVersion = this.getWindows11BrowserMajorVersion(source);
+    if (windows11BrowserMajorVersion !== null && windows11BrowserMajorVersion >= 96) {
+      this.agent.isWindows = true;
+      return 'Windows 11';
     }
     if (this.osPatterns.Windows10.test(source)) {
       this.agent.isWindows = true;
@@ -384,11 +419,11 @@ export class DeviceUUID {
     }
 
     // Mobile OS - check before Mac to avoid false Mac detection on iOS devices
-    if (this.osPatterns.iPad.test(source)) {
+    if (this.hasIOSDeviceOS(source, 'ipad')) {
       this.agent.isiPad = true;
       return 'iOS';
     }
-    if (this.osPatterns.iPhone.test(source)) {
+    if (this.hasIOSDeviceOS(source, 'iphone')) {
       this.agent.isiPhone = true;
       return 'iOS';
     }
@@ -696,7 +731,7 @@ export class DeviceUUID {
     const ua = new DeviceUUID();
     const userAgent = source || getUserAgent();
 
-    ua.agent.source = userAgent.replace(/^\s*/, '').replace(/\s*$/, '');
+    ua.agent.source = userAgent.trim();
     ua.agent.os = ua.getOS(ua.agent.source);
     ua.agent.platform = ua.getPlatform(ua.agent.source);
     ua.agent.browser = ua.getBrowser(ua.agent.source);

--- a/tests/unit/edge-cases.test.ts
+++ b/tests/unit/edge-cases.test.ts
@@ -23,6 +23,14 @@ describe('Edge Cases and Error Conditions', () => {
       expect(uuid.length).toBe(36);
     });
 
+    it('should trim long padded user agents without regex backtracking', () => {
+      const device = new DeviceUUID();
+      const result = device.parse(`${' '.repeat(10000)}CustomBrowser/1.0${' '.repeat(10000)}`);
+
+      expect(result.source).toBe('CustomBrowser/1.0');
+      expect(result.browser).toBe('CustomBrowser');
+    });
+
     it('should handle special characters in user agent', () => {
       const device = new DeviceUUID();
       device.userAgent = 'Test/1.0 (®™©) <script>alert(1)</script>';

--- a/tests/unit/os-detection.test.ts
+++ b/tests/unit/os-detection.test.ts
@@ -19,6 +19,17 @@ describe('Operating System Detection', () => {
       expect(result.os).toBe('Windows 11');
       expect(result.isWindows).toBe(true);
     });
+
+    it('should handle long Windows user agents without regex backtracking', () => {
+      const device = new DeviceUUID();
+      const filler = '; x'.repeat(10000);
+      const result = device.parse(
+        `Mozilla/5.0 (Windows NT 10.0; Win64; x64${filler}) AppleWebKit/537.36 Chrome/120.0.0.0 Safari/537.36`
+      );
+
+      expect(result.os).toBe('Windows 11');
+      expect(result.isWindows).toBe(true);
+    });
   });
 
   describe('macOS', () => {
@@ -96,6 +107,23 @@ describe('Operating System Detection', () => {
       expect(result.os).toBe('iOS');
       expect(result.isiPad).toBe(true);
       expect(result.isTablet).toBe(true);
+    });
+
+    it('should handle long iOS user agents without regex backtracking', () => {
+      const device = new DeviceUUID();
+      const filler = '; x'.repeat(10000);
+
+      const iphone = device.parse(
+        `Mozilla/5.0 (iPhone${filler}; CPU iPhone OS 17_2 like Mac OS X) AppleWebKit/605.1.15`
+      );
+      const ipad = device.parse(
+        `Mozilla/5.0 (iPad${filler}; CPU OS 17_2 like Mac OS X) AppleWebKit/605.1.15`
+      );
+
+      expect(iphone.os).toBe('iOS');
+      expect(iphone.isiPhone).toBe(true);
+      expect(ipad.os).toBe('iOS');
+      expect(ipad.isiPad).toBe(true);
     });
   });
 


### PR DESCRIPTION
## Summary

Fixes the five high-severity CodeQL `js/polynomial-redos` alerts reported in OPE-248 by removing unbounded regular expressions from user-agent parsing.

- Replace Windows 11 inference regex backtracking with bounded string/token parsing.
- Replace iPad/iPhone OS regex checks with bounded user-agent section parsing.
- Replace regex whitespace trimming with native `String.prototype.trim()`.
- Add long user-agent regression coverage for the affected paths.

## Validation

- `npm run test:unit -- tests/unit/os-detection.test.ts tests/unit/edge-cases.test.ts tests/unit/browser-detection.test.ts` (73 passed)
- `npm run test:unit` (530 passed)
- `npm run typecheck`
- `npm run lint`
- `git diff --check`

## CodeQL

Existing alerts 2-6 are still open on `refs/heads/master` before merge. This PR removes the exact regex sources referenced by those alerts so the branch CodeQL run can confirm closure.